### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Doom port for DOS
 
 Build instructions:
-1) Install Open Watcom C.
-2) Install Turbo Assembler(not compatible with x64, use DOSBox).
-3) Add Watcom's bin folder(binnt on Windows, binw on DOS) to the PATH.
+1) Install Open Watcom C version 1.9.
+2) Install Turbo Assembler 2.51, which is distributed with Borland C++ 2.0 (not compatible with x64, use DOSBox).
+3) Add Watcom's bin folder (binnt on Windows, binw on DOS) to the PATH.
 4) Run make.bat.


### PR DESCRIPTION
Refer to specific versions because different versions won't work.